### PR TITLE
chore(deps): group react and react-dom in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,3 +18,8 @@ updates:
     commit-message:
       prefix: chore
       include: scope
+    groups:
+      react:
+        patterns:
+          - "react"
+          - "react-dom"


### PR DESCRIPTION
## Summary

- Adds a `groups.react` block to the `npm` package-ecosystem entry in `.github/dependabot.yml`
- Groups `react` and `react-dom` so Dependabot opens a single PR for both packages
- Mirrors the change landed in `brianespinosa/career` via PR #155

## Test plan

- [ ] CI passes
- [ ] After merge, confirm `git show origin/main:.github/dependabot.yml | grep -A4 "groups:"`