### PR TITLE
fix(deps): resolve 3 Dependabot alerts for js-yaml

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "@vercel/fun/tar": ">=7.5.11",
     "@vercel/node/undici": "^6.24.0",
     "@vercel/prepare-flags-definitions/minimatch": "^10.2.3",
+    "@vercel/python-analysis/js-yaml": ">=4.3.1 <5",
     "@vercel/python-analysis/minimatch": "^10.2.3",
     "vitest/vite": ">=8.0.16 <9"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -4922,14 +4922,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"js-yaml@npm:4.1.1":
-  version: 4.1.1
-  resolution: "js-yaml@npm:4.1.1"
+"js-yaml@npm:>=4.3.1 <5":
+  version: 4.3.1
+  resolution: "js-yaml@npm:4.3.1"
   dependencies:
     argparse: "npm:^2.0.1"
   bin:
     js-yaml: bin/js-yaml.js
-  checksum: 10/a52d0519f0f4ef5b4adc1cde466cb54c50d56e2b4a983b9d5c9c0f2f99462047007a6274d7e95617a21d3c91fde3ee6115536ed70991cd645ba8521058b78f77
+  checksum: 10/2ce71b5d632abbd77da80447bf860e8a0264e54bffe94840984887d58b023761495b523727547904517a6107a1ef189854b361e0fc44995ee13a84f222d7bd42
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

- Resolves 3 Dependabot alerts for `js-yaml` by adding a scoped override for its only parent
- Target version: >=4.3.1
- Resolved version: 4.3.1

## Alerts resolved

| # | CVE | Severity | EPSS | Summary |
|---|---|---|---|---|
| [#105](https://github.com/brianespinosa/kandb.co/security/dependabot/105) | GHSA-5p4m-2wfm-xmqj | high | 0% | Quadratic CPU consumption in `!!omap` resolution (3.x and 4.x); CVE-2026-59870 fix not backported |
| [#78](https://github.com/brianespinosa/kandb.co/security/dependabot/78) | CVE-2026-59869 | high | 34.7% | YAML merge-key chains can force quadratic CPU consumption |
| [#75](https://github.com/brianespinosa/kandb.co/security/dependabot/75) | CVE-2026-53550 | medium | 30.5% | Quadratic-complexity DoS in merge key handling via repeated aliases |

## Merge risk: Medium (5/10)

| Factor | Score | Evidence |
|---|---|---|
| Version delta | 1 | 4.1.1 -> 4.3.1 (minor) |
| Runtime exposure | 1 | transitive under a runtime dependency |
| Usage surface | 0 | no source imports found for parents of js-yaml (build/tooling only) |
| Test signal | 1 | tests pass; affected modules not clearly exercised |
| Verification | 2 | one or more scripts skipped or partially run |

## Dependency chain

```
└─ @vercel/python-analysis@npm:0.13.1
   └─ js-yaml@npm:4.1.1 (via npm:4.1.1)
```

`@vercel/python-analysis` is the sole parent and pinned js-yaml to an exact version (`4.1.1`), so a scoped `resolutions` entry (rather than a version-range bump on a direct dependency) was required to override it.

## Changes

```json
"resolutions": {
  "@vercel/python-analysis/js-yaml": ">=4.3.1 <5"
}
```

`js-yaml` has a single resolved copy in the lockfile, and 4.3.1 clears all three alerts' `vulnerable_range` (the highest floor among the three, `>= 4.0.0, < 4.3.1`, sets the minimum needed).

## Verification

- [x] Lockfile validated: 1 resolved version (`4.3.1`) satisfies `>=4.3.1 <5`, and no remaining copy matches any alert's `vulnerable_range`
- [x] `yarn typecheck` passes
- [x] `yarn test` passes (2/2 test files); js-yaml is consumed by `@vercel/python-analysis`, a build/tooling dependency not exercised by the current test suite, so this is a weak signal
- [x] `yarn build` passes (Next.js production build succeeds)
- [x] `biome check .` passes (2 informational config-version notices only, no errors; ran without `--write` to avoid mutating files during verification — `yarn check` itself was not run for that reason)
- [ ] `yarn knip` skipped: fails on load with `PLAYWRIGHT_BASE_URL is not set` (see `e2e/CLAUDE.md`) — a pre-existing environment requirement unrelated to this dependency change, not fabricated here
- [ ] `yarn e2e` skipped: requires a running/deployed server, not available in this environment; CI is the verifier

## References

- https://github.com/brianespinosa/kandb.co/security/dependabot/105
- https://github.com/brianespinosa/kandb.co/security/dependabot/78
- https://github.com/brianespinosa/kandb.co/security/dependabot/75