### PR TITLE
fix(deps): resolve 19 Dependabot alerts for undici

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,13 +30,16 @@
   },
   "resolutions": {
     "@vercel/backends/srvx": "^0.11.13",
+    "@vercel/blob/undici": ">=6.28.0 <7",
     "@vercel/fastify/@tootallnate/once": "^3.0.1",
     "@vercel/fun/@tootallnate/once": "^3.0.1",
     "@vercel/fun/tar": ">=7.5.11",
-    "@vercel/node/undici": "^6.24.0",
+    "@vercel/node/undici": ">=6.28.0 <7",
     "@vercel/prepare-flags-definitions/minimatch": "^10.2.3",
     "@vercel/python-analysis/js-yaml": ">=4.3.1 <5",
     "@vercel/python-analysis/minimatch": "^10.2.3",
+    "@vercel/sandbox/undici": ">=7.29.0 <8",
+    "vercel/undici": ">=6.28.0 <7",
     "vitest/vite": ">=8.0.16 <9"
   },
   "dependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1005,13 +1005,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@fastify/busboy@npm:^2.0.0":
-  version: 2.1.1
-  resolution: "@fastify/busboy@npm:2.1.1"
-  checksum: 10/2bb8a7eca8289ed14c9eb15239bc1019797454624e769b39a0b90ed204d032403adc0f8ed0d2aef8a18c772205fa7808cf5a1b91f21c7bfc7b6032150b1062c5
-  languageName: node
-  linkType: hard
-
 "@gar/promise-retry@npm:^1.0.0":
   version: 1.0.3
   resolution: "@gar/promise-retry@npm:1.0.3"
@@ -7205,26 +7198,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"undici@npm:5.29.0":
-  version: 5.29.0
-  resolution: "undici@npm:5.29.0"
-  dependencies:
-    "@fastify/busboy": "npm:^2.0.0"
-  checksum: 10/0ceca8924a32acdcc0cfb8dd2d368c217840970aa3f5e314fc169608474be6341c5b8e50cad7bd257dbe3b4e432bc5d0a0d000f83644b54fa11a48735ec52b93
+"undici@npm:>=6.28.0 <7":
+  version: 6.28.0
+  resolution: "undici@npm:6.28.0"
+  checksum: 10/672a7a53bd1f6c80edb73b357ab36e98ef9e474024c442aab2b8ea2bc32f1103cab05525c78661ae724f3e1340e23d03efb9730fba28e76218ab0ec52e15d75a
   languageName: node
   linkType: hard
 
-"undici@npm:^6.23.0, undici@npm:^6.24.0":
-  version: 6.27.0
-  resolution: "undici@npm:6.27.0"
-  checksum: 10/30c18cdb235edf4dd36f8aa3ace1ffaf44060289a7d62ad44c33180d2d74a224015d25574812f62ce9c625b5beb1b0b766495b650fedf356aca11eed7ce2c816
-  languageName: node
-  linkType: hard
-
-"undici@npm:^7.27.1":
-  version: 7.27.2
-  resolution: "undici@npm:7.27.2"
-  checksum: 10/d44f730157713fd2d36a1e98f44aa7661af2188a898b57a85c694013da312fd0c188515e64a59c6bbd4b1f5a79c20b6c564134d06b3ec2f574c990726987e73a
+"undici@npm:>=7.29.0 <8":
+  version: 7.29.0
+  resolution: "undici@npm:7.29.0"
+  checksum: 10/ca73639071bdcbc41e57be1800847fa18f86f8fbf7a5641ff9899f7bbb6f5cecdd593e225f5fd94e31703dcbfaea4a722a3b81cab90c5c4e2b406aec1ae55732
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

- Resolves 19 Dependabot alerts for `undici` by adding scoped `resolutions` overrides
- Two target ranges, one per parent group: `>=6.28.0 <7` and `>=7.29.0 <8`
- Resolved versions: `6.28.0` and `7.29.0` (down from three copies: `5.29.0`, `6.27.0`, `7.27.2`)

undici resolves at three separate major lines in this lockfile via four different
parents. Each was checked individually against every alert's `vulnerable_range`:

| Parent | Declared range | Baseline | Fix applied | Notes |
|---|---|---|---|---|
| `@vercel/blob` | `^6.23.0` | 6.27.0 | `>=6.28.0 <7` | in-range bump |
| `@vercel/node` | `^6.24.0` | 6.27.0 | `>=6.28.0 <7` | merged into pre-existing scoped override |
| `@vercel/sandbox` | `^7.27.1` | 7.27.2 | `>=7.29.0 <8` | in-range bump |
| `vercel` | exact pin `5.29.0` | 5.29.0 | `>=6.28.0 <7` | **crosses a major boundary; see below** |

### Forced major-version jump for the `vercel` parent

`vercel@58.9.1` pins its own copy of `undici` to the exact version `5.29.0` (no
caret, no range). Every fix for the alerts affecting the 5.x/6.x line
(`< 6.24.0`, `< 6.27.0`, `< 6.28.0`) lives at `6.24.0` / `6.27.0` / `6.28.0` —
**there is no patched release in the 5.x line**. Leaving this copy at 5.29.0
would leave 8 of the 19 alerts open. The override therefore deliberately
overrides the parent's exact pin and crosses the 5 -> 6 major boundary to
`>=6.28.0 <7`, the smallest version that clears every alert affecting that
copy. This is flagged here because `vercel`'s own manifest never asked for
anything past `5.29.0`; treat this override as the calculated-risk half of
this PR and weight review accordingly (reflected in the Medium merge-risk
score below, computed off this 5.29.0 -> 6.28.0 major delta).

No pre-existing bare/unscoped `undici` override was found in `package.json`
(one pre-existing scoped entry, `@vercel/node/undici`, was merged into rather
than replaced).

## Alerts resolved

| # | CVE | Severity | EPSS | Summary |
|---|---|---|---|---|
| [#102](https://github.com/brianespinosa/kandb.co/security/dependabot/102) | CVE-2026-15157 | medium | 5.0% | CRLF Injection via blob-like body 'type' property |
| [#101](https://github.com/brianespinosa/kandb.co/security/dependabot/101) | CVE-2026-15157 | medium | 5.0% | CRLF Injection via blob-like body 'type' property |
| [#100](https://github.com/brianespinosa/kandb.co/security/dependabot/100) | CVE-2026-14643 | medium | 13.9% | Cross-user information disclosure via whitespace around equals in Cache-Control directives |
| [#99](https://github.com/brianespinosa/kandb.co/security/dependabot/99) | CVE-2026-16729 | medium | 6.3% | Cookie attribute injection via unsanitized domain and unparsed setCookie fields |
| [#98](https://github.com/brianespinosa/kandb.co/security/dependabot/98) | CVE-2026-16729 | medium | 6.3% | Cookie attribute injection via unsanitized domain and unparsed setCookie fields |
| [#97](https://github.com/brianespinosa/kandb.co/security/dependabot/97) | CVE-2026-16728 | medium | 7.3% | Downstream response desynchronization via retry interceptor |
| [#96](https://github.com/brianespinosa/kandb.co/security/dependabot/96) | CVE-2026-16728 | medium | 7.3% | Downstream response desynchronization via retry interceptor |
| [#95](https://github.com/brianespinosa/kandb.co/security/dependabot/95) | CVE-2026-13697 | high | 25.0% | Cross-user information disclosure and parse-time crash via degenerate private cache directives |
| [#74](https://github.com/brianespinosa/kandb.co/security/dependabot/74) | CVE-2026-11525 | low | 15.0% | Set-Cookie SameSite attribute downgrade via permissive substring matching |
| [#73](https://github.com/brianespinosa/kandb.co/security/dependabot/73) | CVE-2026-9679 | medium | 17.6% | HTTP header injection via Set-Cookie percent-decoding |
| [#71](https://github.com/brianespinosa/kandb.co/security/dependabot/71) | CVE-2026-6733 | low | 12.6% | HTTP response queue poisoning via keep-alive socket reuse |
| [#70](https://github.com/brianespinosa/kandb.co/security/dependabot/70) | CVE-2026-11525 | low | 15.0% | Set-Cookie SameSite attribute downgrade via permissive substring matching |
| [#69](https://github.com/brianespinosa/kandb.co/security/dependabot/69) | CVE-2026-9679 | medium | 17.6% | HTTP header injection via Set-Cookie percent-decoding |
| [#67](https://github.com/brianespinosa/kandb.co/security/dependabot/67) | CVE-2026-6734 | high | 27.6% | Cross-origin request routing via SOCKS5 proxy pool reuse |
| [#66](https://github.com/brianespinosa/kandb.co/security/dependabot/66) | CVE-2026-6733 | low | 12.6% | HTTP response queue poisoning via keep-alive socket reuse |
| [#65](https://github.com/brianespinosa/kandb.co/security/dependabot/65) | CVE-2026-9697 | high | 37.5% | TLS certificate validation bypass via dropped requestTls in SOCKS5 ProxyAgent |
| [#64](https://github.com/brianespinosa/kandb.co/security/dependabot/64) | CVE-2026-9678 | medium | 28.5% | Cross-user information disclosure via shared cache whitespace bypass |
| [#38](https://github.com/brianespinosa/kandb.co/security/dependabot/38) | CVE-2026-1527 | medium | 16.7% | CRLF Injection via `upgrade` option |
| [#37](https://github.com/brianespinosa/kandb.co/security/dependabot/37) | CVE-2026-1525 | medium | 39.5% | HTTP Request/Response Smuggling issue |

## Merge risk: Medium (6/10)

| Factor | Score | Evidence |
|---|---|---|
| Version delta | 2 | 5.29.0 -> 6.28.0 (major) |
| Runtime exposure | 1 | transitive under a runtime dependency |
| Usage surface | 0 | no source imports found for parents of undici (build or tooling only) |
| Test signal | 1 | tests pass; affected modules not clearly exercised |
| Verification | 2 | one or more scripts skipped or partially run |

EPSS (above) is how urgent each individual CVE is; merge risk (this table) is
how risky this specific fix is to merge -- they are independent signals.

## Dependency chain

```
├─ @vercel/blob@npm:2.4.0
│  └─ undici@npm:6.28.0 (via npm:>=6.28.0 <7)
│
├─ @vercel/node@npm:5.9.8
│  └─ undici@npm:6.28.0 (via npm:>=6.28.0 <7)
│
├─ @vercel/sandbox@npm:2.4.0
│  └─ undici@npm:7.29.0 (via npm:>=7.29.0 <8)
│
├─ vercel@npm:58.9.1
│  └─ undici@npm:6.28.0 (via npm:>=6.28.0 <7)
│
└─ vercel@npm:58.9.1 [266e4]
   └─ undici@npm:6.28.0 (via npm:>=6.28.0 <7)
```

## Changes

```json
"resolutions": {
  "@vercel/node/undici": ">=6.28.0 <7",
  "@vercel/blob/undici": ">=6.28.0 <7",
  "@vercel/sandbox/undici": ">=7.29.0 <8",
  "vercel/undici": ">=6.28.0 <7"
}
```

## Verification

- [x] Lockfile validated manually: both resolved copies of `undici` (6.28.0,
      7.29.0) checked individually against every alert's `vulnerable_range`;
      none match
- [x] `yarn typecheck` passes
- [x] `yarn test` passes (2/2, note: 0% coverage on affected modules -- no
      test exercises `undici` usage directly)
- [x] `yarn build` passes (`next build`)
- [x] `biome check .` passes (ran without `--write` to avoid unrelated
      formatting churn; two informational schema-version notices, unrelated
      to this change and present on `main`)
- [ ] `yarn knip` -- skipped: fails identically on `main`
      (`PLAYWRIGHT_BASE_URL is not set. Set it to a Vercel preview deployment
      URL.`), confirmed via a detached worktree against `origin/main`;
      pre-existing, not caused by this change
- [ ] `yarn e2e` -- skipped: requires a live Vercel preview deployment URL,
      not available in this environment; CI's `e2e` job is the verifier

## References

- https://github.com/brianespinosa/kandb.co/security/dependabot/102
- https://github.com/brianespinosa/kandb.co/security/dependabot/101
- https://github.com/brianespinosa/kandb.co/security/dependabot/100
- https://github.com/brianespinosa/kandb.co/security/dependabot/99
- https://github.com/brianespinosa/kandb.co/security/dependabot/98
- https://github.com/brianespinosa/kandb.co/security/dependabot/97
- https://github.com/brianespinosa/kandb.co/security/dependabot/96
- https://github.com/brianespinosa/kandb.co/security/dependabot/95
- https://github.com/brianespinosa/kandb.co/security/dependabot/74
- https://github.com/brianespinosa/kandb.co/security/dependabot/73
- https://github.com/brianespinosa/kandb.co/security/dependabot/71
- https://github.com/brianespinosa/kandb.co/security/dependabot/70
- https://github.com/brianespinosa/kandb.co/security/dependabot/69
- https://github.com/brianespinosa/kandb.co/security/dependabot/67
- https://github.com/brianespinosa/kandb.co/security/dependabot/66
- https://github.com/brianespinosa/kandb.co/security/dependabot/65
- https://github.com/brianespinosa/kandb.co/security/dependabot/64
- https://github.com/brianespinosa/kandb.co/security/dependabot/38
- https://github.com/brianespinosa/kandb.co/security/dependabot/37
