### PR TITLE
fix(deps): resolve Dependabot alert for nanoid

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "@vercel/python-analysis/js-yaml": ">=4.3.1 <5",
     "@vercel/python-analysis/minimatch": "^10.2.3",
     "@vercel/sandbox/undici": ">=7.29.0 <8",
+    "postcss/nanoid": ">=3.3.18 <4",
     "vercel/undici": ">=6.28.0 <7",
     "vitest/vite": ">=8.0.16 <9"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -5560,16 +5560,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nanoid@npm:^3.3.16":
-  version: 3.3.17
-  resolution: "nanoid@npm:3.3.17"
-  bin:
-    nanoid: bin/nanoid.cjs
-  checksum: 10/54c3238ba6ea31c173ccf70922481814892075dbf1b4636abec249d0b34d5594fc9a8892c04872068674010a11fa3d18316dc06e59e700def131ff9d8e740426
-  languageName: node
-  linkType: hard
-
-"nanoid@npm:^3.3.17":
+"nanoid@npm:>=3.3.18 <4":
   version: 3.3.18
   resolution: "nanoid@npm:3.3.18"
   bin:


### PR DESCRIPTION
## Summary

- Resolves 1 Dependabot alert for `nanoid` by adding a scoped override (`postcss/nanoid`)
- Target version: >=3.3.18
- Resolved version: 3.3.18

## Alerts resolved

| # | CVE | Severity | EPSS | Summary |
|---|---|---|---|---|
| [#108](https://github.com/brianespinosa/kandb.co/security/dependabot/108) | CVE-2026-67213 | high | 24.5% | nanoid: custom generators can loop indefinitely when size is zero |

## Merge risk: Medium (4/10)

| Factor | Score | Evidence |
|---|---|---|
| Version delta | 0 | 3.3.17 -> 3.3.18 (patch) |
| Runtime exposure | 1 | transitive under a runtime dependency |
| Usage surface | 0 | no source imports found for parents of nanoid (build or tooling only) |
| Test signal | 1 | tests pass; affected modules not clearly exercised |
| Verification | 2 | one or more scripts skipped or partially run |

## Dependency chain

```
└─ postcss@npm:8.5.23
   └─ nanoid@npm:3.3.17 (via npm:^3.3.16)
```

nanoid is a single-copy transitive dependency of `postcss`. The patched version 3.3.18 stays within postcss's declared `^3.3.16` range, so this is a routine patch bump, not a major-boundary jump.

## Changes

```json
"postcss/nanoid": ">=3.3.18 <4"
```

## Verification

- [x] Lockfile validated: 1 resolved version satisfies `>=3.3.18 <4`
- [x] `yarn typecheck` passes
- [x] `yarn test` passes (2/2; coverage shows nothing directly exercises postcss/nanoid, tooling-only dependency)
- [x] `yarn build` passes
- [x] `biome check .` passes (only pre-existing schema-version infos, unrelated to this change)
- [ ] `yarn knip` skipped: fails without `PLAYWRIGHT_BASE_URL` (requires a real Vercel preview deployment URL); not fabricated, deferred to CI
- [ ] `yarn e2e` skipped: requires a running server; deferred to CI

## References

- https://github.com/brianespinosa/kandb.co/security/dependabot/108