### PR TITLE
fix(deps): resolve Dependabot alert for brace-expansion

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "@vercel/python-analysis/js-yaml": ">=4.3.1 <5",
     "@vercel/python-analysis/minimatch": "^10.2.3",
     "@vercel/sandbox/undici": ">=7.29.0 <8",
+    "minimatch@npm:10.2.5/brace-expansion": ">=5.0.7 <6",
     "postcss/nanoid": ">=3.3.18 <4",
     "vercel/undici": ">=6.28.0 <7",
     "vitest/vite": ">=8.0.16 <9"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3683,6 +3683,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"brace-expansion@npm:>=5.0.7 <6":
+  version: 5.0.9
+  resolution: "brace-expansion@npm:5.0.9"
+  dependencies:
+    balanced-match: "npm:^4.0.2"
+  checksum: 10/d8683d612919212c7cf298861acd1c15101e7e2ad186e7ae9747390e5b3fc9e9b55ce71107570d32985784d9d88fbbe438d725863aed7b0f3d08d5f080535eec
+  languageName: node
+  linkType: hard
+
 "brace-expansion@npm:^1.1.7":
   version: 1.1.18
   resolution: "brace-expansion@npm:1.1.18"
@@ -3690,15 +3699,6 @@ __metadata:
     balanced-match: "npm:^1.0.0"
     concat-map: "npm:0.0.1"
   checksum: 10/b55a3c03239b8d2127c7cbb3408c9ad3a556a8c303bf3064df78bfb7c093160fc8f6e0a32e42a850a78eba12f29ccf6ef997690b9acf945d242c56c61c4aa977
-  languageName: node
-  linkType: hard
-
-"brace-expansion@npm:^5.0.5":
-  version: 5.0.5
-  resolution: "brace-expansion@npm:5.0.5"
-  dependencies:
-    balanced-match: "npm:^4.0.2"
-  checksum: 10/f259b2ddf04489da9512ad637ba6b4ef2d77abd4445d20f7f1714585f153435200a53fa6a2e4a5ee974df14ddad4cd16421f6f803e96e8b452bd48598878d0ee
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

- Resolves 1 Dependabot alert for `brace-expansion` by adding a version-scoped override
- Target version: >=5.0.7 <6
- Resolved version: 5.0.9 (for the affected copy)

`brace-expansion` is a transitive dependency pulled in twice under `minimatch`, at two
different major lines:

- `minimatch@10.2.5` -> `brace-expansion@5.0.5` (vulnerable, alert range `>=3.0.0, <5.0.7`)
- `minimatch@3.1.5` -> `brace-expansion@1.1.18` (outside the vulnerable range, safe as-is)

A plain parent-scoped override (`minimatch/brace-expansion`) would apply to both
`minimatch` instances and force-bump the never-vulnerable 1.x copy across a major
boundary for no reason. Instead this uses yarn's version-scoped resolution key,
`minimatch@npm:10.2.5/brace-expansion`, so only the vulnerable copy under
`minimatch@10.2.5` is touched.

`validate` (which checks every resolved copy against the derived constraint
`>=5.0.7 <6`, not against the alert) flags the 1.1.18 copy as a "violation." That
verdict is overridden here deliberately: 1.1.18 is below the alert's vulnerable
range (`>=3.0.0`) and was never in scope.

## Alerts resolved

| # | CVE | Severity | EPSS | Summary |
|---|---|---|---|---|
| [#76](https://github.com/brianespinosa/kandb.co/security/dependabot/76) | CVE-2026-13149 | high | 27.5% | brace-expansion: DoS via exponential-time expansion of consecutive non-expanding {} groups |

## Merge risk: Medium (4/10)

| Factor | Score | Evidence |
|---|---|---|
| Version delta | 0 | 5.0.5 -> 5.0.9 (patch) |
| Runtime exposure | 1 | transitive under a runtime dependency |
| Usage surface | 0 | no source imports found for parents of brace-expansion (build or tooling only) |
| Test signal | 1 | tests pass; affected modules not clearly exercised |
| Verification | 2 | one or more scripts skipped or partially run |

## Dependency chain

```
├─ minimatch@npm:10.2.5
│  └─ brace-expansion@npm:5.0.5 (via npm:^5.0.5)
│
└─ minimatch@npm:3.1.5
   └─ brace-expansion@npm:1.1.18 (via npm:^1.1.7)
```

## Changes

```json
"minimatch@npm:10.2.5/brace-expansion": ">=5.0.7 <6"
```

## Verification

- [x] Lockfile validated: manually confirmed every resolved copy against the alert's
      `vulnerable_range` (`>=3.0.0, <5.0.7`), not just the derived constraint. 5.0.9
      clears it; 1.1.18 was never in it and is untouched.
- [x] `yarn typecheck` passes
- [x] `yarn test` passes (2/2)
- [x] `yarn build` passes
- [x] `biome check .` passes (used instead of `yarn check`, which mutates via `--write`;
      two pre-existing informational schema-version warnings in `biome.json`, unrelated
      to this change)
- [ ] `yarn knip` skipped: hard-fails without `PLAYWRIGHT_BASE_URL` set, no value to
      fabricate
- [ ] `yarn e2e` skipped: requires a running dev server
- `yarn install` produced no warnings (repo CLAUDE.md requires all install warnings be
  resolved before merge; none were introduced)

## References

- https://github.com/brianespinosa/kandb.co/security/dependabot/76